### PR TITLE
주유소 선택, 팀원 선택 구현

### DIFF
--- a/src/main/java/com/ezkorea/hybrid_app/app/Config/TestDataInit.java
+++ b/src/main/java/com/ezkorea/hybrid_app/app/Config/TestDataInit.java
@@ -37,6 +37,9 @@ public class TestDataInit {
 
     @PostConstruct
     public void testMemberDataInit() {
+        if (!memberRepository.existsByUsername("ez_dev_team_master")) {
+            memberService.saveNewMember(makeNewMember("ez_dev_team_master", "개발팀", Role.MASTER));
+        }
         if (!memberRepository.existsByUsername("01011111111")) {
             Member member = memberService.saveNewMember(makeNewMember("01011111111", "고봉민", Role.LEADER));
             Team newTeam = teamService.saveNewTeam(member.getName() + "팀");

--- a/src/main/java/com/ezkorea/hybrid_app/app/Config/TestDataInit.java
+++ b/src/main/java/com/ezkorea/hybrid_app/app/Config/TestDataInit.java
@@ -51,13 +51,13 @@ public class TestDataInit {
         if (gasStationRepository.findAll().size() == 0) {
             GasStation gs = GasStation.builder()
                     .stationName("배트맨 주유소")
-                    .stationLocation("경기도 수원시 장안구")
+                    .stationLocation("경기도 수원시 장안구 랄로 1234번길 56")
                     .build();
             gasStationRepository.save(gs);
 
             gs = GasStation.builder()
                     .stationName("한문철 주유소")
-                    .stationLocation("경기도 용인시 수지구")
+                    .stationLocation("경기도 용인시 수지구 랄로 1004번길 44")
                     .build();
             gasStationRepository.save(gs);
         }

--- a/src/main/java/com/ezkorea/hybrid_app/app/Config/TestDataInit.java
+++ b/src/main/java/com/ezkorea/hybrid_app/app/Config/TestDataInit.java
@@ -13,8 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-import javax.transaction.Transactional;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -27,19 +25,23 @@ public class TestDataInit {
     @PostConstruct
     public void testMemberDataInit() {
         if (!memberRepository.existsByUsername("test1")) {
-            memberService.saveNewMember(makeNewMember("test1", "고봉민"));
+            memberService.saveNewMember(makeNewMember("test1", "고봉민", true));
         }
         if (!memberRepository.existsByUsername("test2")) {
-            memberService.saveNewMember(makeNewMember("test2", "김경자"));
+            memberService.saveNewMember(makeNewMember("test2", "김경자", false));
+        }
+        if (!memberRepository.existsByUsername("test3")) {
+            memberService.saveNewMember(makeNewMember("test3", "한문철", false));
         }
     }
 
-    public SignUpDto makeNewMember(String username, String name) {
+    public SignUpDto makeNewMember(String username, String name, boolean isLeader) {
         SignUpDto newDto = new SignUpDto();
         newDto.setUsername(username);
         newDto.setPassword("1234");
         newDto.setName(name);
         newDto.setSex("MALE");
+        newDto.setLeader(isLeader);
 
         return newDto;
     }
@@ -48,13 +50,13 @@ public class TestDataInit {
     public void testGasStationDataInit() {
         if (gasStationRepository.findAll().size() == 0) {
             GasStation gs = GasStation.builder()
-                    .stationName("테스트 주유소1")
+                    .stationName("배트맨 주유소")
                     .stationLocation("경기도 수원시 장안구")
                     .build();
             gasStationRepository.save(gs);
 
             gs = GasStation.builder()
-                    .stationName("테스트 주유소2")
+                    .stationName("한문철 주유소")
                     .stationLocation("경기도 용인시 수지구")
                     .build();
             gasStationRepository.save(gs);

--- a/src/main/java/com/ezkorea/hybrid_app/app/Config/TestDataInit.java
+++ b/src/main/java/com/ezkorea/hybrid_app/app/Config/TestDataInit.java
@@ -4,6 +4,7 @@ import com.ezkorea.hybrid_app.domain.gas.GasStation;
 import com.ezkorea.hybrid_app.domain.gas.GasStationRepository;
 import com.ezkorea.hybrid_app.domain.user.division.Division;
 import com.ezkorea.hybrid_app.domain.user.division.Position;
+import com.ezkorea.hybrid_app.domain.user.division.Status;
 import com.ezkorea.hybrid_app.domain.user.member.Member;
 import com.ezkorea.hybrid_app.domain.user.member.Role;
 import com.ezkorea.hybrid_app.domain.user.team.Team;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import javax.transaction.Transactional;
+import java.util.Random;
 
 @Component
 @RequiredArgsConstructor
@@ -35,18 +37,30 @@ public class TestDataInit {
 
     @PostConstruct
     public void testMemberDataInit() {
-        if (!memberRepository.existsByUsername("test1")) {
+        if (!memberRepository.existsByUsername("01011111111")) {
             Member member = memberService.saveNewMember(makeNewMember("01011111111", "고봉민", Role.LEADER));
             Team newTeam = teamService.saveNewTeam(member.getName() + "팀");
-            Division division = divisionService.saveNewDivision(newTeam, member, divisionService.makeNewDivisionDto("승인", Position.LEADER));
+            Division division = divisionService.saveNewDivision(newTeam, member, divisionService.makeNewDivisionDto(Status.COMPLETE, Position.LEADER));
             member.setDivision(division);
             memberRepository.save(member);
         }
-        if (!memberRepository.existsByUsername("test2")) {
+        if (!memberRepository.existsByUsername("01011111111")) {
             memberService.saveNewMember(makeNewMember("01022222222", "김경자", Role.EMPLOYEE));
         }
-        if (!memberRepository.existsByUsername("test3")) {
+        if (!memberRepository.existsByUsername("01011111111")) {
             memberService.saveNewMember(makeNewMember("01033333333", "한문철", Role.EMPLOYEE));
+        }
+        StringBuilder sb;
+        for (int i = 0; i < 15; i++) {
+            Random random = new Random();
+            sb = new StringBuilder();
+            for (int j = 0; j < 11; j++) {
+                int createNum = random.nextInt(9);
+                sb.append(createNum);
+            }
+            if (!memberRepository.existsByUsername(sb.toString())) {
+                memberService.saveNewMember(makeNewMember(sb.toString(), sb.substring(0, 3), Role.EMPLOYEE));
+            }
         }
     }
 

--- a/src/main/java/com/ezkorea/hybrid_app/app/Config/TestDataInit.java
+++ b/src/main/java/com/ezkorea/hybrid_app/app/Config/TestDataInit.java
@@ -2,6 +2,7 @@ package com.ezkorea.hybrid_app.app.Config;
 
 import com.ezkorea.hybrid_app.domain.gas.GasStation;
 import com.ezkorea.hybrid_app.domain.gas.GasStationRepository;
+import com.ezkorea.hybrid_app.domain.user.member.Role;
 import com.ezkorea.hybrid_app.domain.wiper.WiperSize;
 import com.ezkorea.hybrid_app.domain.wiper.WiperSort;
 import com.ezkorea.hybrid_app.domain.user.member.MemberRepository;
@@ -25,23 +26,23 @@ public class TestDataInit {
     @PostConstruct
     public void testMemberDataInit() {
         if (!memberRepository.existsByUsername("test1")) {
-            memberService.saveNewMember(makeNewMember("test1", "고봉민", true));
+            memberService.saveNewMember(makeNewMember("01011111111", "고봉민", Role.LEADER));
         }
         if (!memberRepository.existsByUsername("test2")) {
-            memberService.saveNewMember(makeNewMember("test2", "김경자", false));
+            memberService.saveNewMember(makeNewMember("01022222222", "김경자", Role.EMPLOYEE));
         }
         if (!memberRepository.existsByUsername("test3")) {
-            memberService.saveNewMember(makeNewMember("test3", "한문철", false));
+            memberService.saveNewMember(makeNewMember("01033333333", "한문철", Role.EMPLOYEE));
         }
     }
 
-    public SignUpDto makeNewMember(String username, String name, boolean isLeader) {
+    public SignUpDto makeNewMember(String username, String name, Role role) {
         SignUpDto newDto = new SignUpDto();
         newDto.setUsername(username);
         newDto.setPassword("1234");
         newDto.setName(name);
         newDto.setSex("MALE");
-        newDto.setLeader(isLeader);
+        newDto.setRole(role);
 
         return newDto;
     }

--- a/src/main/java/com/ezkorea/hybrid_app/app/Config/TestDataInit.java
+++ b/src/main/java/com/ezkorea/hybrid_app/app/Config/TestDataInit.java
@@ -2,18 +2,26 @@ package com.ezkorea.hybrid_app.app.Config;
 
 import com.ezkorea.hybrid_app.domain.gas.GasStation;
 import com.ezkorea.hybrid_app.domain.gas.GasStationRepository;
+import com.ezkorea.hybrid_app.domain.user.division.Division;
+import com.ezkorea.hybrid_app.domain.user.division.Position;
+import com.ezkorea.hybrid_app.domain.user.member.Member;
 import com.ezkorea.hybrid_app.domain.user.member.Role;
+import com.ezkorea.hybrid_app.domain.user.team.Team;
 import com.ezkorea.hybrid_app.domain.wiper.WiperSize;
 import com.ezkorea.hybrid_app.domain.wiper.WiperSort;
 import com.ezkorea.hybrid_app.domain.user.member.MemberRepository;
 import com.ezkorea.hybrid_app.domain.wiper.Wiper;
 import com.ezkorea.hybrid_app.domain.wiper.WiperRepository;
+import com.ezkorea.hybrid_app.service.user.division.DivisionService;
 import com.ezkorea.hybrid_app.service.user.member.MemberService;
+import com.ezkorea.hybrid_app.service.user.team.TeamService;
+import com.ezkorea.hybrid_app.web.dto.DivisionDto;
 import com.ezkorea.hybrid_app.web.dto.SignUpDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+import javax.transaction.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -22,11 +30,17 @@ public class TestDataInit {
     private final WiperRepository wiperRepository;
     private final GasStationRepository gasStationRepository;
     private final MemberService memberService;
+    private final TeamService teamService;
+    private final DivisionService divisionService;
 
     @PostConstruct
     public void testMemberDataInit() {
         if (!memberRepository.existsByUsername("test1")) {
-            memberService.saveNewMember(makeNewMember("01011111111", "고봉민", Role.LEADER));
+            Member member = memberService.saveNewMember(makeNewMember("01011111111", "고봉민", Role.LEADER));
+            Team newTeam = teamService.saveNewTeam(member.getName() + "팀");
+            Division division = divisionService.saveNewDivision(newTeam, member, divisionService.makeNewDivisionDto("승인", Position.LEADER));
+            member.setDivision(division);
+            memberRepository.save(member);
         }
         if (!memberRepository.existsByUsername("test2")) {
             memberService.saveNewMember(makeNewMember("01022222222", "김경자", Role.EMPLOYEE));

--- a/src/main/java/com/ezkorea/hybrid_app/domain/task/DailyTask.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/task/DailyTask.java
@@ -27,6 +27,7 @@ public class DailyTask extends BaseEntity {
     private List<SaleProduct> productList = new ArrayList<>();
 
     @OneToOne
+    @Setter
     private GasStation gasStation;
 
     @ManyToOne(targetEntity = Member.class, fetch = FetchType.LAZY)

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/division/Division.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/division/Division.java
@@ -23,10 +23,15 @@ public class Division extends BaseEntity {
     private Member member;
 
     @Enumerated(EnumType.STRING)
+    @Setter
     private Position position;
 
+    @Setter
     private String status;
 
-
+    public void addBasicInfo(Team team, Member member) {
+        this.member = member;
+        this.team = team;
+    }
 
 }

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/division/Division.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/division/Division.java
@@ -1,0 +1,32 @@
+package com.ezkorea.hybrid_app.domain.user.division;
+
+import com.ezkorea.hybrid_app.domain.base.BaseEntity;
+import com.ezkorea.hybrid_app.domain.user.member.Member;
+import com.ezkorea.hybrid_app.domain.user.team.Team;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString(callSuper = true)
+public class Division extends BaseEntity {
+
+    @OneToOne
+    private Team team;
+
+    @OneToOne(targetEntity = Member.class, fetch = FetchType.LAZY)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private Position position;
+
+    private String status;
+
+
+
+}

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/division/Division.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/division/Division.java
@@ -22,12 +22,13 @@ public class Division extends BaseEntity {
     @OneToOne(targetEntity = Member.class, fetch = FetchType.LAZY)
     private Member member;
 
-    @Enumerated(EnumType.STRING)
     @Setter
+    @Enumerated(EnumType.STRING)
     private Position position;
 
     @Setter
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private Status status;
 
     public void addBasicInfo(Team team, Member member) {
         this.member = member;

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/division/DivisionRepository.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/division/DivisionRepository.java
@@ -1,7 +1,12 @@
 package com.ezkorea.hybrid_app.domain.user.division;
 
+import com.ezkorea.hybrid_app.domain.user.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DivisionRepository extends JpaRepository<Division, Long> {
+
+    Optional<Division> findByMember(Member member);
 
 }

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/division/DivisionRepository.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/division/DivisionRepository.java
@@ -1,0 +1,7 @@
+package com.ezkorea.hybrid_app.domain.user.division;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DivisionRepository extends JpaRepository<Division, Long> {
+
+}

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/division/Position.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/division/Position.java
@@ -1,0 +1,16 @@
+package com.ezkorea.hybrid_app.domain.user.division;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Position {
+
+    LEADER("팀장"),
+    SUB_LEADER("부팀장"),
+    MEMBER("팀원");
+
+    private final String viewName;
+
+}

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/division/Status.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/division/Status.java
@@ -1,0 +1,16 @@
+package com.ezkorea.hybrid_app.domain.user.division;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Status {
+
+    COMPLETE("승인"),
+    AWAIT("대기"),
+    DENY("거절");
+
+    private final String viewName;
+
+}

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/member/Member.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/member/Member.java
@@ -4,7 +4,6 @@ import com.ezkorea.hybrid_app.domain.base.BaseEntity;
 import com.ezkorea.hybrid_app.domain.task.DailyTask;
 import com.ezkorea.hybrid_app.domain.user.commute.CommuteTime;
 import com.ezkorea.hybrid_app.domain.user.division.Division;
-import com.ezkorea.hybrid_app.domain.user.team.Team;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -38,7 +37,9 @@ public class Member extends BaseEntity {
     private String name;
 
     @Setter
-    private boolean isLeader;
+    @Column(name = "member_role")
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<CommuteTime> commuteTimeList = new ArrayList<>();

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/member/Member.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/member/Member.java
@@ -3,6 +3,7 @@ package com.ezkorea.hybrid_app.domain.user.member;
 import com.ezkorea.hybrid_app.domain.base.BaseEntity;
 import com.ezkorea.hybrid_app.domain.task.DailyTask;
 import com.ezkorea.hybrid_app.domain.user.commute.CommuteTime;
+import com.ezkorea.hybrid_app.domain.user.division.Division;
 import com.ezkorea.hybrid_app.domain.user.team.Team;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -49,7 +50,11 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<DailyTask> taskList = new ArrayList<>();
 
-    @ManyToOne(targetEntity = Team.class, fetch = FetchType.LAZY)
-    private Team team;
+    @OneToOne(targetEntity = Division.class, fetch = FetchType.LAZY)
+    private Division division;
+
+    public void setDivision(Division division) {
+        this.division = division;
+    }
 
 }

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/member/Member.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/member/Member.java
@@ -1,9 +1,9 @@
 package com.ezkorea.hybrid_app.domain.user.member;
 
 import com.ezkorea.hybrid_app.domain.base.BaseEntity;
-import com.ezkorea.hybrid_app.domain.sale.SaleProduct;
 import com.ezkorea.hybrid_app.domain.task.DailyTask;
 import com.ezkorea.hybrid_app.domain.user.commute.CommuteTime;
+import com.ezkorea.hybrid_app.domain.user.team.Team;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,9 +12,7 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,6 +36,9 @@ public class Member extends BaseEntity {
     @Setter
     private String name;
 
+    @Setter
+    private boolean isLeader;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<CommuteTime> commuteTimeList = new ArrayList<>();
 
@@ -47,5 +48,8 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<DailyTask> taskList = new ArrayList<>();
+
+    @ManyToOne(targetEntity = Team.class, fetch = FetchType.LAZY)
+    private Team team;
 
 }

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/member/MemberRepository.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/member/MemberRepository.java
@@ -3,10 +3,14 @@ package com.ezkorea.hybrid_app.domain.user.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String username);
 
     boolean existsByUsername(String username);
+
+    List<Member> findAllByRole(Role role);
+
 }

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/member/Role.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/member/Role.java
@@ -1,0 +1,17 @@
+package com.ezkorea.hybrid_app.domain.user.member;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    MASTER("대표"),
+    MANAGER("경리"),
+    LEADER("팀장"),
+    EMPLOYEE("직원");
+
+    private final String viewName;
+
+}

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/member/SecurityUser.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/member/SecurityUser.java
@@ -15,6 +15,7 @@ public class SecurityUser extends User {
     private final String username;
     private final String name;
     private final String sex;
+    private final Role role;
     private final LocalDateTime createDate;
 
     public SecurityUser(Member member, List<GrantedAuthority> authorities) {
@@ -24,6 +25,7 @@ public class SecurityUser extends User {
         this.name = member.getName();
         this.username = member.getUsername();
         this.createDate = member.getCreateDate();
+        this.role = member.getRole();
     }
 
     public Member getMember() {
@@ -32,6 +34,7 @@ public class SecurityUser extends User {
                 .createDate(createDate)
                 .name(name)
                 .sex(sex)
+                .role(role)
                 .username(username)
                 .build();
     }

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/team/Team.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/team/Team.java
@@ -1,0 +1,29 @@
+package com.ezkorea.hybrid_app.domain.user.team;
+
+import com.ezkorea.hybrid_app.domain.base.BaseEntity;
+import com.ezkorea.hybrid_app.domain.user.member.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString(callSuper = true)
+public class Team extends BaseEntity {
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Member> memberList = new ArrayList<>();
+
+}

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/team/Team.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/team/Team.java
@@ -23,7 +23,7 @@ import java.util.List;
 @ToString(callSuper = true)
 public class Team extends BaseEntity {
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
     private List<Member> memberList = new ArrayList<>();
 
 }

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/team/Team.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/team/Team.java
@@ -23,7 +23,6 @@ import java.util.List;
 @ToString(callSuper = true)
 public class Team extends BaseEntity {
 
-    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
-    private List<Member> memberList = new ArrayList<>();
+    private String name;
 
 }

--- a/src/main/java/com/ezkorea/hybrid_app/domain/user/team/TeamRepository.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/user/team/TeamRepository.java
@@ -1,0 +1,6 @@
+package com.ezkorea.hybrid_app.domain.user.team;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+}

--- a/src/main/java/com/ezkorea/hybrid_app/service/sales/GasStationService.java
+++ b/src/main/java/com/ezkorea/hybrid_app/service/sales/GasStationService.java
@@ -1,0 +1,20 @@
+package com.ezkorea.hybrid_app.service.sales;
+
+import com.ezkorea.hybrid_app.domain.gas.GasStation;
+import com.ezkorea.hybrid_app.domain.gas.GasStationRepository;
+import com.ezkorea.hybrid_app.web.exception.GasStationNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GasStationService {
+    private final GasStationRepository gsRepository;
+
+    public GasStation findByStationName(String name) {
+        return gsRepository.findByStationName(name)
+                .orElseThrow( () -> new GasStationNotFoundException(name + "를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/ezkorea/hybrid_app/service/sales/SaleService.java
+++ b/src/main/java/com/ezkorea/hybrid_app/service/sales/SaleService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import javax.transaction.Transactional;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +29,7 @@ public class SaleService {
     private final DailyTaskRepository dtRepository;
 
     private final WiperService wiperService;
+    private final GasStationService gsService;
 
     public void saveDailyTask(Member member) {
         DailyTask dt = DailyTask.builder()
@@ -52,11 +54,15 @@ public class SaleService {
                 .wiper(currentWiper)
                 .build();
         spRepository.save(newSaleProduct);
-//        saveTaskProduct();
     }
 
     public List<GasStation> findAllGasStation() {
         return gsRepository.findAll();
     }
 
+    @Transactional
+    public void saveDailyGasStation(String stationName, Member member) {
+        DailyTask task = findByMemberAndDate(member);
+        task.setGasStation(gsService.findByStationName(stationName));
+    }
 }

--- a/src/main/java/com/ezkorea/hybrid_app/service/sales/SaleService.java
+++ b/src/main/java/com/ezkorea/hybrid_app/service/sales/SaleService.java
@@ -1,5 +1,7 @@
 package com.ezkorea.hybrid_app.service.sales;
 
+import com.ezkorea.hybrid_app.domain.gas.GasStation;
+import com.ezkorea.hybrid_app.domain.gas.GasStationRepository;
 import com.ezkorea.hybrid_app.domain.sale.SaleProduct;
 import com.ezkorea.hybrid_app.domain.sale.SaleProductRepository;
 import com.ezkorea.hybrid_app.domain.task.DailyTask;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +24,7 @@ public class SaleService {
 
     private final ModelMapper modelMapper;
     private final SaleProductRepository spRepository;
+    private final GasStationRepository gsRepository;
     private final DailyTaskRepository dtRepository;
 
     private final WiperService wiperService;
@@ -49,6 +53,10 @@ public class SaleService {
                 .build();
         spRepository.save(newSaleProduct);
 //        saveTaskProduct();
+    }
+
+    public List<GasStation> findAllGasStation() {
+        return gsRepository.findAll();
     }
 
 }

--- a/src/main/java/com/ezkorea/hybrid_app/service/user/division/DivisionService.java
+++ b/src/main/java/com/ezkorea/hybrid_app/service/user/division/DivisionService.java
@@ -3,6 +3,7 @@ package com.ezkorea.hybrid_app.service.user.division;
 import com.ezkorea.hybrid_app.domain.user.division.Division;
 import com.ezkorea.hybrid_app.domain.user.division.DivisionRepository;
 import com.ezkorea.hybrid_app.domain.user.division.Position;
+import com.ezkorea.hybrid_app.domain.user.division.Status;
 import com.ezkorea.hybrid_app.domain.user.member.Member;
 import com.ezkorea.hybrid_app.domain.user.team.Team;
 import com.ezkorea.hybrid_app.service.user.member.MemberService;
@@ -35,7 +36,10 @@ public class DivisionService {
                 .orElseThrow( () -> new MemberNotFoundException("해당 멤버의 소속을 찾을 수 없습니다."));
     }
 
-    public DivisionDto makeNewDivisionDto(String status, Position position) {
+    /**
+     * 테스트 계정 전용 메소드
+     * */
+    public DivisionDto makeNewDivisionDto(Status status, Position position) {
         DivisionDto newDto = new DivisionDto();
         newDto.setPosition(position);
         newDto.setStatus(status);
@@ -43,10 +47,9 @@ public class DivisionService {
     }
 
     @Transactional
-    public void setEmployeeDivision(String username, Member leader) {
-        Member employee = memberService.findByUsername(username);
+    public void setEmployeeDivision(DivisionDto dto, Member leader) {
+        Member employee = memberService.findByUsername(dto.getUsername());
         Division leaderDivision = findByMember(leader);
-        DivisionDto dto = makeNewDivisionDto("승인", Position.MEMBER);
         Division division = saveNewDivision(
                 leaderDivision.getTeam(), employee, dto
         );

--- a/src/main/java/com/ezkorea/hybrid_app/service/user/division/DivisionService.java
+++ b/src/main/java/com/ezkorea/hybrid_app/service/user/division/DivisionService.java
@@ -1,0 +1,56 @@
+package com.ezkorea.hybrid_app.service.user.division;
+
+import com.ezkorea.hybrid_app.domain.user.division.Division;
+import com.ezkorea.hybrid_app.domain.user.division.DivisionRepository;
+import com.ezkorea.hybrid_app.domain.user.division.Position;
+import com.ezkorea.hybrid_app.domain.user.member.Member;
+import com.ezkorea.hybrid_app.domain.user.team.Team;
+import com.ezkorea.hybrid_app.service.user.member.MemberService;
+import com.ezkorea.hybrid_app.web.dto.DivisionDto;
+import com.ezkorea.hybrid_app.web.exception.MemberNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DivisionService {
+    private final ModelMapper mapper;
+    private final DivisionRepository divisionRepository;
+    private final MemberService memberService;
+    public Division saveNewDivision(Team team, Member member, DivisionDto dto) {
+
+        Division division = mapper.map(dto, Division.class);
+        division.addBasicInfo(team, member);
+
+        return divisionRepository.save(division);
+    }
+
+    public Division findByMember(Member member) {
+        return divisionRepository.findByMember(member)
+                .orElseThrow( () -> new MemberNotFoundException("해당 멤버의 소속을 찾을 수 없습니다."));
+    }
+
+    public DivisionDto makeNewDivisionDto(String status, Position position) {
+        DivisionDto newDto = new DivisionDto();
+        newDto.setPosition(position);
+        newDto.setStatus(status);
+        return newDto;
+    }
+
+    @Transactional
+    public void setEmployeeDivision(String username, Member leader) {
+        Member employee = memberService.findByUsername(username);
+        Division leaderDivision = findByMember(leader);
+        DivisionDto dto = makeNewDivisionDto("승인", Position.MEMBER);
+        Division division = saveNewDivision(
+                leaderDivision.getTeam(), employee, dto
+        );
+
+        employee.setDivision(division);
+    }
+}

--- a/src/main/java/com/ezkorea/hybrid_app/service/user/member/CustomUserDetailsService.java
+++ b/src/main/java/com/ezkorea/hybrid_app/service/user/member/CustomUserDetailsService.java
@@ -26,9 +26,8 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .orElseThrow( () -> new UsernameNotFoundException("사원번호를 찾을 수 없습니다.") );
         List<GrantedAuthority> authorities = new ArrayList<>();
 
-        if (member.getUsername().contains("master")) {
+        if (member.getUsername().contains("ez_dev_team_master")) {
             authorities.add(new SimpleGrantedAuthority("ADMIN"));
-        } else if (member.getUsername().contains("manage")) {
             authorities.add(new SimpleGrantedAuthority("MANAGER"));
         }
         authorities.add(new SimpleGrantedAuthority("MEMBER"));

--- a/src/main/java/com/ezkorea/hybrid_app/service/user/member/MemberService.java
+++ b/src/main/java/com/ezkorea/hybrid_app/service/user/member/MemberService.java
@@ -4,6 +4,7 @@ import com.ezkorea.hybrid_app.domain.user.commute.CommuteTime;
 import com.ezkorea.hybrid_app.domain.user.commute.CommuteTimeRepository;
 import com.ezkorea.hybrid_app.domain.user.member.Member;
 import com.ezkorea.hybrid_app.domain.user.member.MemberRepository;
+import com.ezkorea.hybrid_app.domain.user.member.Role;
 import com.ezkorea.hybrid_app.domain.user.member.SecurityUser;
 import com.ezkorea.hybrid_app.service.sales.SaleService;
 import com.ezkorea.hybrid_app.service.user.commute.CommuteService;
@@ -121,5 +122,9 @@ public class MemberService {
                         .saveCommuteTime(currentMember, status)
                 )
         );
+    }
+
+    public List<Member> findByRole(Role role) {
+        return memberRepository.findAllByRole(role);
     }
 }

--- a/src/main/java/com/ezkorea/hybrid_app/service/user/team/TeamService.java
+++ b/src/main/java/com/ezkorea/hybrid_app/service/user/team/TeamService.java
@@ -1,0 +1,22 @@
+package com.ezkorea.hybrid_app.service.user.team;
+
+import com.ezkorea.hybrid_app.domain.user.team.Team;
+import com.ezkorea.hybrid_app.domain.user.team.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+
+    public Team saveNewTeam(String name) {
+        return teamRepository.save(Team.builder()
+                .name(name)
+                .build());
+    }
+
+}

--- a/src/main/java/com/ezkorea/hybrid_app/web/controller/mapping/DivisionController.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/controller/mapping/DivisionController.java
@@ -1,0 +1,23 @@
+package com.ezkorea.hybrid_app.web.controller.mapping;
+
+import com.ezkorea.hybrid_app.domain.user.member.Role;
+import com.ezkorea.hybrid_app.service.user.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class DivisionController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/team")
+    public String saveTeam(Model model) {
+        model.addAttribute("members", memberService.findByRole(Role.EMPLOYEE));
+        return "team/member-view";
+    }
+}

--- a/src/main/java/com/ezkorea/hybrid_app/web/controller/mapping/SaleController.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/controller/mapping/SaleController.java
@@ -3,6 +3,7 @@ package com.ezkorea.hybrid_app.web.controller.mapping;
 import com.ezkorea.hybrid_app.domain.task.DailyTask;
 import com.ezkorea.hybrid_app.domain.user.member.SecurityUser;
 import com.ezkorea.hybrid_app.service.sales.SaleService;
+import com.ezkorea.hybrid_app.service.user.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class SaleController {
 
     private final SaleService saleService;
+    private final MemberService memberService;
 
     @GetMapping("/sales")
     public String showSalesPage(@AuthenticationPrincipal SecurityUser securityUser,

--- a/src/main/java/com/ezkorea/hybrid_app/web/controller/mapping/SaleController.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/controller/mapping/SaleController.java
@@ -1,5 +1,6 @@
 package com.ezkorea.hybrid_app.web.controller.mapping;
 
+import com.ezkorea.hybrid_app.domain.task.DailyTask;
 import com.ezkorea.hybrid_app.domain.user.member.SecurityUser;
 import com.ezkorea.hybrid_app.service.sales.SaleService;
 import lombok.RequiredArgsConstructor;
@@ -10,14 +11,22 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 @RequiredArgsConstructor
-public class SalesController {
+public class SaleController {
 
     private final SaleService saleService;
 
     @GetMapping("/sales")
     public String showSalesPage(@AuthenticationPrincipal SecurityUser securityUser,
                                 Model model) {
-        model.addAttribute("dailyTask", saleService.findByMemberAndDate(securityUser.getMember()));
+
+        DailyTask currentTask = saleService.findByMemberAndDate(securityUser.getMember());
+
+        if (currentTask.getGasStation() == null) {
+            model.addAttribute("stations", saleService.findAllGasStation());
+            return "sales/sales-select";
+        }
+
+        model.addAttribute("dailyTask", currentTask);
         return "sales/sales-detail";
     }
 

--- a/src/main/java/com/ezkorea/hybrid_app/web/controller/rest/DivisionRestController.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/controller/rest/DivisionRestController.java
@@ -3,8 +3,10 @@ package com.ezkorea.hybrid_app.web.controller.rest;
 import com.ezkorea.hybrid_app.domain.user.member.SecurityUser;
 import com.ezkorea.hybrid_app.service.user.division.DivisionService;
 import com.ezkorea.hybrid_app.service.user.team.TeamService;
+import com.ezkorea.hybrid_app.web.dto.DivisionDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,12 +21,17 @@ import java.util.Map;
 public class DivisionRestController {
 
     private final DivisionService divisionService;
+    private final ModelMapper mapper;
+
     @PostMapping("/team")
     public HttpStatus saveTeam(@RequestBody Map<String, Object> data,
                                @AuthenticationPrincipal SecurityUser securityUser) {
+
+        DivisionDto dto = mapper.map(data, DivisionDto.class);
+
         String username = (String) data.get("username");
 
-        divisionService.setEmployeeDivision(username, securityUser.getMember());
+        divisionService.setEmployeeDivision(dto, securityUser.getMember());
 
         return HttpStatus.OK;
     }

--- a/src/main/java/com/ezkorea/hybrid_app/web/controller/rest/DivisionRestController.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/controller/rest/DivisionRestController.java
@@ -1,0 +1,31 @@
+package com.ezkorea.hybrid_app.web.controller.rest;
+
+import com.ezkorea.hybrid_app.domain.user.member.SecurityUser;
+import com.ezkorea.hybrid_app.service.user.division.DivisionService;
+import com.ezkorea.hybrid_app.service.user.team.TeamService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class DivisionRestController {
+
+    private final DivisionService divisionService;
+    @PostMapping("/team")
+    public HttpStatus saveTeam(@RequestBody Map<String, Object> data,
+                               @AuthenticationPrincipal SecurityUser securityUser) {
+        String username = (String) data.get("username");
+
+        divisionService.setEmployeeDivision(username, securityUser.getMember());
+
+        return HttpStatus.OK;
+    }
+}

--- a/src/main/java/com/ezkorea/hybrid_app/web/controller/rest/SalesRestController.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/controller/rest/SalesRestController.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @Slf4j
@@ -20,6 +22,16 @@ public class SalesRestController {
                                        @AuthenticationPrincipal SecurityUser securityUser) {
 
         saleService.saveSaleProduct(wiperDto, securityUser.getMember());
+
+        return HttpStatus.OK;
+    }
+
+    @PostMapping("/sales/select")
+    public HttpStatus saveTeam(@RequestBody Map<String, Object> data,
+                               @AuthenticationPrincipal SecurityUser securityUser) {
+
+        saleService.saveDailyGasStation((String) data.get("stationName"), securityUser.getMember());
+
 
         return HttpStatus.OK;
     }

--- a/src/main/java/com/ezkorea/hybrid_app/web/dto/DivisionDto.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/dto/DivisionDto.java
@@ -1,0 +1,13 @@
+package com.ezkorea.hybrid_app.web.dto;
+
+import com.ezkorea.hybrid_app.domain.user.division.Position;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DivisionDto {
+    private String status;
+    private Position position;
+
+}

--- a/src/main/java/com/ezkorea/hybrid_app/web/dto/DivisionDto.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/dto/DivisionDto.java
@@ -1,13 +1,15 @@
 package com.ezkorea.hybrid_app.web.dto;
 
 import com.ezkorea.hybrid_app.domain.user.division.Position;
+import com.ezkorea.hybrid_app.domain.user.division.Status;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class DivisionDto {
-    private String status;
+    private String username;
+    private Status status;
     private Position position;
 
 }

--- a/src/main/java/com/ezkorea/hybrid_app/web/dto/SaleSelectDto.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/dto/SaleSelectDto.java
@@ -1,0 +1,11 @@
+package com.ezkorea.hybrid_app.web.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SaleSelectDto {
+    private String gasStation;
+    private String member;
+}

--- a/src/main/java/com/ezkorea/hybrid_app/web/dto/SignUpDto.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/dto/SignUpDto.java
@@ -9,4 +9,5 @@ public class SignUpDto {
     private String password;
     private String sex;
     private String name;
+    private boolean isLeader;
 }

--- a/src/main/java/com/ezkorea/hybrid_app/web/dto/SignUpDto.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/dto/SignUpDto.java
@@ -1,5 +1,6 @@
 package com.ezkorea.hybrid_app.web.dto;
 
+import com.ezkorea.hybrid_app.domain.user.member.Role;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,4 +11,5 @@ public class SignUpDto {
     private String sex;
     private String name;
     private boolean isLeader;
+    private Role role;
 }

--- a/src/main/java/com/ezkorea/hybrid_app/web/exception/ExceptionHandlerController.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/exception/ExceptionHandlerController.java
@@ -23,4 +23,11 @@ public class ExceptionHandlerController {
 
         return Script.href("/", e.getMessage());
     }
+
+    @ExceptionHandler(value = GasStationNotFoundException.class)
+    public @ResponseBody String notExistGasStaion(GasStationNotFoundException e) {
+        log.error("GasStationNotFoundException={}", e);
+
+        return Script.href("/", e.getMessage());
+    }
 }

--- a/src/main/java/com/ezkorea/hybrid_app/web/exception/GasStationNotFoundException.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/exception/GasStationNotFoundException.java
@@ -1,0 +1,8 @@
+package com.ezkorea.hybrid_app.web.exception;
+
+public class GasStationNotFoundException extends RuntimeException {
+
+    public GasStationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,4 +15,4 @@ spring:
     password: 1234
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop

--- a/src/main/resources/templates/layout/fragments/main/header.html
+++ b/src/main/resources/templates/layout/fragments/main/header.html
@@ -66,6 +66,9 @@
         <div class="right_side">
 
           <div class="header_widgets">
+            <div>
+
+            </div>
             <!--<a href="pages-upgrade.html" class="is_link">  Upgrade </a>
             <a href="#" class="is_icon" uk-tooltip="title: Cart">
               <svg fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M3 1a1 1 0 000 2h1.22l.305 1.222a.997.997 0 00.01.042l1.358 5.43-.893.892C3.74 11.846 4.632 14 6.414 14H15a1 1 0 000-2H6.414l1-1H14a1 1 0 00.894-.553l3-6A1 1 0 0017 3H6.28l-.31-1.243A1 1 0 005 1H3zM16 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM6.5 18a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path></svg>
@@ -177,7 +180,7 @@
               </div>
             </div>-->
 
-            <a href="#" class="is_icon" uk-tooltip="title: Notifications">
+            <!--<a href="#" class="is_icon" uk-tooltip="title: Notifications">
               <svg fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z"></path></svg>
               <span>3</span>
             </a>
@@ -350,7 +353,7 @@
                   </li>
                 </ul>
               </div>
-            </div>
+            </div>-->
 
             <!-- Message -->
             <!--<a href="#" class="is_icon" uk-tooltip="title: Message">
@@ -476,13 +479,7 @@
                 <svg fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"></path></svg>
                 프로필 설정
               </a>
-              <a href="group-feed.html">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                  <path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z"  clip-rule="evenodd" />
-                </svg>
-                매니저 페이지
-              </a>
-              <a id="night-mode" class="btn-night-mode">
+              <!--<a id="night-mode" class="btn-night-mode">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                   <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
                 </svg>
@@ -490,7 +487,7 @@
                 <span class="btn-night-mode-switch">
                   <span class="uk-switch-button"></span>
                 </span>
-              </a>
+              </a>-->
               <form th:action="@{/logout}" method="post">
                 <a>
                   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/main/resources/templates/layout/fragments/main/side-bar.html
+++ b/src/main/resources/templates/layout/fragments/main/side-bar.html
@@ -2,6 +2,7 @@
 <html lang="ko"
       class="no-js"
       xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
       xmlns="http://www.w3.org/1999/html">
 
   <!-- sidebar -->
@@ -27,12 +28,14 @@
                   <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z" />
               </svg><span> 팀원 </span></a>
           </li>
-        <!--<li class="active"><a href="pages.html">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="text-yellow-500">
-            <path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"></path>
-          </svg>
-          <span> Pages </span> </a>
-        </li>
+          <li sec:authorize="hasRole('MANAGER')">
+              <a href="pages.html">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="text-blue-500">
+                  <path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"></path>
+              </svg>
+              <span> 매니징 </span> </a>
+          </li>
+        <!--
         <li><a href="videos.html">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="text-red-500">
             <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm3 2h6v4H7V5zm8 8v2h1v-2h-1zm-2-2H7v4h6v-4zm2 0h1V9h-1v2zm1-4V5h-1v2h1zM5 5v2H4V5h1zm0 4H4v2h1V9zm-1 4h1v2H4v-2z" clip-rule="evenodd" />

--- a/src/main/resources/templates/layout/fragments/main/side-bar.html
+++ b/src/main/resources/templates/layout/fragments/main/side-bar.html
@@ -22,6 +22,11 @@
             <path d="M2 13.692V16a2 2 0 002 2h12a2 2 0 002-2v-2.308A24.974 24.974 0 0110 15c-2.796 0-5.487-.46-8-1.308z" />
           </svg> <span> 판매 </span> </a>
         </li>
+          <li><a href="/team" th:if="${member.getRole().getViewName() == '팀장'}">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="text-blue-500">
+                  <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z" />
+              </svg><span> 팀원 </span></a>
+          </li>
         <!--<li class="active"><a href="pages.html">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="text-yellow-500">
             <path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"></path>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -8,7 +8,7 @@
   <head th:replace="layout/fragments/common/head :: head"></head>
 
   <body>
-    <div id="wrapper">
+    <div id="wrapper" th:with="member = ${#authentication.getPrincipal().getMember()}">
 
       <!-- Header -->
       <div class="dark">
@@ -18,7 +18,7 @@
       <div th:replace="layout/fragments/main/side-bar :: sidebar"></div>
 
       <div class="main_content">
-        <div class="mcontainer" th:with="member = ${#authentication.getPrincipal().getMember()}">
+        <div class="mcontainer">
           <main layout:fragment="main"></main>
         </div>
         <!-- Footer -->

--- a/src/main/resources/templates/sales/sales-detail.html
+++ b/src/main/resources/templates/sales/sales-detail.html
@@ -33,7 +33,11 @@
                                 <div class="flex items-center space-x-3">
                                     <div class="p-1.5 rounded-full text-xl">⛽️</div>
                                     <div class="flex-1">
-                                        <div><span class="text-2xl font-semibold"> 태양 제2 주유소 </span>(수정)</div>
+                                        <div>
+                                            <span class="text-2xl font-semibold" th:text="${dailyTask.getGasStation().getStationName()}"> 주유소 이름 </span>
+                                            <span class="text-sm">(수정)</span>
+                                        </div>
+                                        <p th:text="${dailyTask.getGasStation().getStationLocation()}"></p>
                                     </div>
                                 </div>
                                 <div class="flex items-center space-x-3">

--- a/src/main/resources/templates/sales/sales-select.html
+++ b/src/main/resources/templates/sales/sales-select.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ko"
+      class="no-js"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout}"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security" xmlns="http://www.w3.org/1999/html">
+
+<body>
+
+    <main layout:fragment="main">
+        <style>
+            .icon {
+                display: inline-block;
+                vertical-align: middle;
+            }
+        </style>
+        <div class="lg:space-x-12">
+            <form id="selectForm" onsubmit="return false;">
+                <div class="lg:w-full card">
+
+                    <div class="p-10 pt-4 divide-y divide-gray-100">
+
+                        <div class="md:py-8 py-3">
+                            <h2 class="text-xl font-bold">
+                                <span th:text="${member.getName()}"></span> 팀장님
+                                <p>주유소와 팀원을 선택해주세요.</p>
+                            </h2>
+                        </div>
+
+                        <div class="md:py-8 py-3">
+                            <h1 class="block text-lg font-bold mb-4"> 주유소 및 팀원 선택  </h1>
+                            <div class="md:flex">
+                                <div class="md:w-2/3 space-y-4 -mt-2">
+                                    <div class="flex items-center space-x-3">
+                                        <div class="p-1.5 rounded-full text-xl">⛽️</div>
+                                        <div class="flex-1">
+                                            <select id="gasStation" name="gasStation" class="border border-gray-300 text-sm rounded-lg block w-full p-2.5">
+                                                <option th:each="station : ${stations}" th:text="|${station.getStationName()}(${station.getStationLocation()})|" th:value="${station.getStationName()}"></option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="flex items-center space-x-3">
+                                        <div class="p-1.5 rounded-full text-xl">👨‍👦‍👦</div>
+                                        <div class="flex-1">
+                                            <select id="member" name="member" class="border border-gray-300 text-sm rounded-lg block w-full p-2.5">
+                                                <option value="123">123</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="md:py-8 py-3">
+                            <div class="space-y-3">
+                                <button type="submit" class="btn bg-blue-600 py-2 rounded-lg w-full">저장하기</button>
+                            </div>
+                        </div>
+
+                    </div>
+
+                </div>
+            </form>
+        </div>
+    </main>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/sales/sales-select.html
+++ b/src/main/resources/templates/sales/sales-select.html
@@ -10,9 +10,36 @@
 
     <main layout:fragment="main">
         <style>
-            .icon {
-                display: inline-block;
-                vertical-align: middle;
+            .live-search-list {
+                -webkit-box-sizing: border-box;
+                -moz-box-sizing: border-box;
+                box-sizing: border-box;
+                padding: 1em;
+                -webkit-border-radius: 5px;
+                -moz-border-radius: 5px;
+                border-radius: 5px;
+                font-family: 'Lato', sans-serif;
+                color: #fff;
+            }
+
+            .live-search-box {
+                width: 100%;
+                display: block;
+                padding: 1em;
+                -webkit-box-sizing: border-box;
+                -moz-box-sizing: border-box;
+                box-sizing: border-box;
+                border: 1px solid #3498db;
+                -webkit-border-radius: 5px;
+                -moz-border-radius: 5px;
+                border-radius: 5px;
+            }
+
+            .live-search-list li {
+                color: #fff;
+                list-style: none;
+                padding: 0;
+                margin: 5px 0;
             }
         </style>
         <div class="lg:space-x-12">
@@ -23,8 +50,8 @@
 
                         <div class="md:py-8 py-3">
                             <h2 class="text-xl font-bold">
-                                <span th:text="${member.getName()}"></span> 팀장님
-                                <p>주유소와 팀원을 선택해주세요.</p>
+                                <span th:text="|${member.getName()} ${member.getRole().getViewName()}|"></span>님
+                                <p>오늘 근무할 주유소를 선택해주세요.</p>
                             </h2>
                         </div>
 
@@ -40,21 +67,13 @@
                                             </select>
                                         </div>
                                     </div>
-                                    <div class="flex items-center space-x-3">
-                                        <div class="p-1.5 rounded-full text-xl">👨‍👦‍👦</div>
-                                        <div class="flex-1">
-                                            <select id="member" name="member" class="border border-gray-300 text-sm rounded-lg block w-full p-2.5">
-                                                <option value="123">123</option>
-                                            </select>
-                                        </div>
-                                    </div>
                                 </div>
                             </div>
                         </div>
 
                         <div class="md:py-8 py-3">
                             <div class="space-y-3">
-                                <button type="submit" class="btn bg-blue-600 py-2 rounded-lg w-full">저장하기</button>
+                                <button id="submit" type="submit" class="btn bg-blue-600 py-2 rounded-lg w-full">저장하기</button>
                             </div>
                         </div>
 
@@ -63,6 +82,50 @@
                 </div>
             </form>
         </div>
+        <script>
+            $("#submit").on("click", function (){
+                var stationName = $("#gasStation option:selected").val();
+                Swal.fire({
+                    html: stationName + '을 선택하시겠습니까?',
+                    showDenyButton: true,
+                    confirmButtonText: '선택',
+                    denyButtonText: `취소`,
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        let data = {
+                            stationName : stationName
+                        };
+                        console.log(data);
+                        $.ajax({
+                            type: "POST",
+                            url: "/sales/select",
+                            dataType: 'json',
+                            contentType: 'application/json; charset=utf-8',
+                            data: JSON.stringify(data),
+                            beforeSend: function (jqXHR, settings) {
+                                var header = $("meta[name='_csrf_header']").attr("content");
+                                var token = $("meta[name='_csrf']").attr("content");
+                                jqXHR.setRequestHeader(header, token);
+                            },
+                            success: function () {
+                                Swal.fire({
+                                    icon: 'success',
+                                    text: '정상적으로 저장되었습니다.',
+                                }).then(() => {
+                                    $(location).attr('href', '/sales');
+                                })
+                            },
+                            error: function (xhr, status, error) {
+                                Swal.fire({
+                                    icon: 'error',
+                                    text: '작성한 내용을 다시 확인해주세요!',
+                                })
+                            }
+                        });
+                    }
+                })
+            });
+        </script>
     </main>
 
 </body>

--- a/src/main/resources/templates/sales/sales-select.html
+++ b/src/main/resources/templates/sales/sales-select.html
@@ -56,7 +56,7 @@
                         </div>
 
                         <div class="md:py-8 py-3">
-                            <h1 class="block text-lg font-bold mb-4"> 주유소 및 팀원 선택  </h1>
+                            <h1 class="block text-lg font-bold mb-4"> 주유소 선택  </h1>
                             <div class="md:flex">
                                 <div class="md:w-2/3 space-y-4 -mt-2">
                                     <div class="flex items-center space-x-3">

--- a/src/main/resources/templates/team/member-view.html
+++ b/src/main/resources/templates/team/member-view.html
@@ -56,33 +56,51 @@
                         </div>
 
                         <div class="md:py-8 py-3">
-                            <h1 class="block text-lg font-bold mb-4"> 팀원 선택  </h1>
+                            <h1 class="block text-lg font-bold mb-4"> 👨‍👦‍👦 팀원 선택  </h1>
                             <div class="md:flex">
                                 <div class="md:w-2/3 space-y-4 -mt-2">
-                                    <div class="flex items-center space-x-3">
-                                        <div class="p-1.5 rounded-full text-xl">👨‍👦‍👦</div>
+                                    <div id="select-div" class="items-center space-x-3">
                                         <div class="flex-1">
                                             <input type="text" class="live-search-box" placeholder="search here" />
 
-                                            <ul id="search-result" class="live-search-list hidden">
-                                                <form id="inviteMember" onsubmit="return false">
-                                                    <li th:each="user : ${members}">
+                                            <ul id="search-result" class="live-search-list">
+                                                <li th:each="user : ${members}">
+                                                    <form th:id="|inviteMember${user.getId()}|" onsubmit="return false">
                                                         <div class="flex items-center space-x-4 hover:bg-gray-100 rounded-md -mx-2 p-2">
                                                             <div class="w-10 h-10 flex-shrink-0 rounded-md relative">
                                                                 <img src="assets/images/avatars/avatar-3.jpg" class="absolute w-full h-full inset-0 rounded-full" alt="">
                                                             </div>
                                                             <div class="flex-1">
                                                                 <h3 class="text-base font-semibold capitalize" th:text="|${user.getName()}(${#strings.substring(user.getUsername(), 7, 11)})|"> 유저이름 </h3>
+                                                                <th:block th:if="${user.getDivision() == null}">
+                                                                    <input type="hidden" name="username" th:value="${user.getUsername()}">
+                                                                    <input type="hidden" name="status" value="AWAIT">
+                                                                    <div>
+                                                                        <select name="position">
+                                                                            <option th:each="position : ${T(com.ezkorea.hybrid_app.domain.user.division.Position).values()}"
+                                                                                    th:if="${!position.equals(T(com.ezkorea.hybrid_app.domain.user.division.Position).LEADER)}"
+                                                                                    th:selected="${position.equals(T(com.ezkorea.hybrid_app.domain.user.division.Position).MEMBER)}"
+                                                                                    th:value="${position}"
+                                                                                    th:text="${position.viewName}">
+                                                                            </option>
+                                                                        </select>
+                                                                    </div>
+                                                                </th:block>
                                                             </div>
                                                             <th:block th:if="${user.getDivision() == null}">
-                                                                <button type="submit" th:data-value="${user.getUsername()}" th:onclick="|inviteBtn.doInvite(this.getAttribute('data-value'))|" class="flex items-center justify-center h-9 px-4 rounded-md border font-semibold"> 초대하기 </button>
+                                                                <button type="submit" th:data-value="${user.getId()}" th:onclick="|inviteBtn.doInvite(this.getAttribute('data-value'))|" class="flex items-center text-blue-600 justify-center h-9 px-4 rounded-md border font-semibold"> 초대하기 </button>
                                                             </th:block>
                                                             <th:block th:if="${user.getDivision() != null}">
-                                                                <button type="button" class="flex items-center justify-center h-9 px-4 rounded-md border font-semibold"> 팀존재 </button>
+                                                                <th:block th:if="${user.getDivision().getStatus().equals('승인')}">
+                                                                    <button type="button" class="flex items-center justify-center h-9 text-red-600 px-4 rounded-md border font-semibold"> 팀존재 </button>
+                                                                </th:block>
+                                                                <th:block th:if="${user.getDivision().getStatus().equals('대기')}">
+                                                                    <button type="button" class="flex items-center justify-center h-9 text-yellow-600 px-4 rounded-md border font-semibold"> 수락대기 </button>
+                                                                </th:block>
                                                             </th:block>
                                                         </div>
-                                                    </li>
-                                                </form>
+                                                    </form>
+                                                </li>
                                             </ul>
                                         </div>
                                     </div>
@@ -115,7 +133,6 @@
                     $('.live-search-list li').each(function(){
 
                         if ($(this).filter('[data-search-term *= ' + searchTerm + ']').length > 0 || searchTerm.length < 1) {
-                            $('#search-result').removeClass("hidden");
                             $(this).show();
                         } else {
                             $(this).hide();
@@ -126,15 +143,33 @@
                 });
 
             });
+            jQuery.fn.serializeObject = function() {
+                var obj = null;
+                try {
+                    if (this[0].tagName && this[0].tagName.toUpperCase() == "FORM") {
+                        var arr = this.serializeArray();
+                        if (arr) {
+                            obj = {};
+                            jQuery.each(arr, function() {
+                                obj[this.name] = this.value;
+                            });
+                        }//if ( arr ) {
+                    }
+                } catch (e) {
+                    alert(e.message);
+                } finally {
+                }
+
+                return obj;
+            };
             let inviteBtn = {
-                doInvite: function (username) {
-                    var data = {
-                        username: username
-                    };
+                doInvite: function (id) {
+                    console.log(id);
+                    console.log($(`#inviteMember${id}`).serializeObject());
                     $.ajax({
                         type: "POST",
                         url: "/team",
-                        data: JSON.stringify(data),
+                        data: JSON.stringify($(`#inviteMember${id}`).serializeObject()),
                         dataType: 'json',
                         contentType: 'application/json; charset=utf-8',
                         beforeSend: function (jqXHR, settings) {
@@ -147,7 +182,7 @@
                                 icon: 'success',
                                 text: '정상적으로 초대되었습니다!',
                             }).then(() => {
-                                $(location).attr('href', '/team');
+                                $('#select-div').load(location.href+' #select-div');
                             })
                         },
                         error: function (xhr, status, error) {

--- a/src/main/resources/templates/team/member-view.html
+++ b/src/main/resources/templates/team/member-view.html
@@ -91,10 +91,10 @@
                                                                 <button type="submit" th:data-value="${user.getId()}" th:onclick="|inviteBtn.doInvite(this.getAttribute('data-value'))|" class="flex items-center text-blue-600 justify-center h-9 px-4 rounded-md border font-semibold"> 초대하기 </button>
                                                             </th:block>
                                                             <th:block th:if="${user.getDivision() != null}">
-                                                                <th:block th:if="${user.getDivision().getStatus().equals('승인')}">
+                                                                <th:block th:if="${user.getDivision().getStatus().equals(T(com.ezkorea.hybrid_app.domain.user.division.Status).COMPLETE)}">
                                                                     <button type="button" class="flex items-center justify-center h-9 text-red-600 px-4 rounded-md border font-semibold"> 팀존재 </button>
                                                                 </th:block>
-                                                                <th:block th:if="${user.getDivision().getStatus().equals('대기')}">
+                                                                <th:block th:if="${user.getDivision().getStatus().equals(T(com.ezkorea.hybrid_app.domain.user.division.Status).AWAIT)}">
                                                                     <button type="button" class="flex items-center justify-center h-9 text-yellow-600 px-4 rounded-md border font-semibold"> 수락대기 </button>
                                                                 </th:block>
                                                             </th:block>

--- a/src/main/resources/templates/team/member-view.html
+++ b/src/main/resources/templates/team/member-view.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="ko"
+      class="no-js"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout}"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security" xmlns="http://www.w3.org/1999/html">
+
+<body>
+
+    <main layout:fragment="main">
+        <style>
+            .live-search-list {
+                -webkit-box-sizing: border-box;
+                -moz-box-sizing: border-box;
+                box-sizing: border-box;
+                padding: 1em;
+                -webkit-border-radius: 5px;
+                -moz-border-radius: 5px;
+                border-radius: 5px;
+                font-family: 'Lato', sans-serif;
+                color: #fff;
+            }
+
+            .live-search-box {
+                width: 100%;
+                display: block;
+                padding: 1em;
+                -webkit-box-sizing: border-box;
+                -moz-box-sizing: border-box;
+                box-sizing: border-box;
+                border: 1px solid #3498db;
+                -webkit-border-radius: 5px;
+                -moz-border-radius: 5px;
+                border-radius: 5px;
+            }
+
+            .live-search-list li {
+                color: #fff;
+                list-style: none;
+                padding: 0;
+                margin: 5px 0;
+            }
+        </style>
+        <div class="lg:space-x-12">
+            <form id="selectForm" onsubmit="return false;">
+                <div class="lg:w-full card">
+
+                    <div class="p-10 pt-4 divide-y divide-gray-100">
+
+                        <div class="md:py-8 py-3">
+                            <h2 class="text-xl font-bold">
+                                <span th:text="|${member.getName()} ${member.getRole().getViewName()}|"></span>님
+                                <p>함께할 팀원을 선택해주세요.</p>
+                            </h2>
+                        </div>
+
+                        <div class="md:py-8 py-3">
+                            <h1 class="block text-lg font-bold mb-4"> 팀원 선택  </h1>
+                            <div class="md:flex">
+                                <div class="md:w-2/3 space-y-4 -mt-2">
+                                    <div class="flex items-center space-x-3">
+                                        <div class="p-1.5 rounded-full text-xl">👨‍👦‍👦</div>
+                                        <div class="flex-1">
+                                            <input type="text" class="live-search-box" placeholder="search here" />
+
+                                            <ul id="search-result" class="live-search-list hidden">
+                                                <form id="inviteMember" onsubmit="return false">
+                                                    <li th:each="user : ${members}">
+                                                        <div class="flex items-center space-x-4 hover:bg-gray-100 rounded-md -mx-2 p-2">
+                                                            <div class="w-10 h-10 flex-shrink-0 rounded-md relative">
+                                                                <img src="assets/images/avatars/avatar-3.jpg" class="absolute w-full h-full inset-0 rounded-full" alt="">
+                                                            </div>
+                                                            <div class="flex-1">
+                                                                <h3 class="text-base font-semibold capitalize" th:text="|${user.getName()}(${#strings.substring(user.getUsername(), 7, 11)})|"> 유저이름 </h3>
+                                                            </div>
+                                                            <th:block th:if="${user.getDivision() == null}">
+                                                                <button type="submit" th:data-value="${user.getUsername()}" th:onclick="|inviteBtn.doInvite(this.getAttribute('data-value'))|" class="flex items-center justify-center h-9 px-4 rounded-md border font-semibold"> 초대하기 </button>
+                                                            </th:block>
+                                                            <th:block th:if="${user.getDivision() != null}">
+                                                                <button type="button" class="flex items-center justify-center h-9 px-4 rounded-md border font-semibold"> 팀존재 </button>
+                                                            </th:block>
+                                                        </div>
+                                                    </li>
+                                                </form>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="md:py-8 py-3">
+                            <div class="space-y-3">
+                                <button type="submit" class="btn bg-blue-600 py-2 rounded-lg w-full">저장하기</button>
+                            </div>
+                        </div>
+
+                    </div>
+
+                </div>
+            </form>
+        </div>
+        <script th:inline="javascript">
+            jQuery(document).ready(function($){
+
+                $('.live-search-list li').each(function(){
+                    $(this).attr('data-search-term', $(this).text().toLowerCase());
+                });
+
+                $('.live-search-box').on('keyup', function(){
+
+                    var searchTerm = $(this).val().toLowerCase();
+
+                    $('.live-search-list li').each(function(){
+
+                        if ($(this).filter('[data-search-term *= ' + searchTerm + ']').length > 0 || searchTerm.length < 1) {
+                            $('#search-result').removeClass("hidden");
+                            $(this).show();
+                        } else {
+                            $(this).hide();
+                        }
+
+                    });
+
+                });
+
+            });
+            let inviteBtn = {
+                doInvite: function (username) {
+                    var data = {
+                        username: username
+                    };
+                    $.ajax({
+                        type: "POST",
+                        url: "/team",
+                        data: JSON.stringify(data),
+                        dataType: 'json',
+                        contentType: 'application/json; charset=utf-8',
+                        beforeSend: function (jqXHR, settings) {
+                            var header = $("meta[name='_csrf_header']").attr("content");
+                            var token = $("meta[name='_csrf']").attr("content");
+                            jqXHR.setRequestHeader(header, token);
+                        },
+                        success: function () {
+                            Swal.fire({
+                                icon: 'success',
+                                text: '정상적으로 초대되었습니다!',
+                            }).then(() => {
+                                $(location).attr('href', '/team');
+                            })
+                        },
+                        error: function (xhr, status, error) {
+                            Swal.fire({
+                                icon: 'error',
+                                text: '페이지를 새로고침하고 다시 시도해주세요!',
+                            })
+                        }
+                    });
+                }
+            }
+        </script>
+    </main>
+
+</body>
+
+</html>


### PR DESCRIPTION
## Entity 관련 변동사항
- `Team` : 팀
- `Division` : 소속
    - `(ENUM)Position` : 직위
    - `(ENUM)Status` : 상태(승인, 거절, 대기)
- `Member` : 회원
    - `(ENUM)Role` : 사내 직책

## 도메인 별 개발 및 수정 내역

### Member

- Division ↔️ Member 양방향 1:1 참조
- Role 지정
    - db에서는 `member_role`로 다루도록 네이밍
        - role : mySql에서 사용하는 예약어

### GasStation
<img width="317" alt="스크린샷 2023-01-27 오후 5 22 11" src="https://user-images.githubusercontent.com/82663161/215040575-59c0d361-4a7d-4137-8326-ff1abeccd0ff.png">

- 판매 페이지로 가기 전 주유소 정보가 등록되어 있지 않다면 선택 페이지로 가도록 지정
- DB에 등록된 모든 주유소 목록을 가져와 선택하도록 구현

#### 보완할 사항

- 주유소 수정 미구현
- 검색 및 정렬된 상태로 보여지도록 수정 예정

### Division && Team
- Division ➡️ Team 단반향 참조
<img width="291" alt="스크린샷 2023-01-27 오후 6 32 56" src="https://user-images.githubusercontent.com/82663161/215053934-ea757547-a956-402d-a907-ac47f27f2ebf.png">

- Member의 Role이 LEADER(팀장)일 때만, 메뉴에 팀원 탭이 보이도록 구현
- 팀원 페이지에서는 해당 유저를 팀원 및 부팀장으로 초대할 수 있음

<img width="319" alt="스크린샷 2023-01-27 오후 6 21 55" src="https://user-images.githubusercontent.com/82663161/215051741-79bd35c3-75f5-47d5-961e-c41b18ee88ff.png">

- 검색은 이름과 핸드폰 뒷자리로 조회가 가능하도록 구현(오픈소스 가져옴)
- 각 초대하기 버튼마다 고유한 id를 가진 form 태그가 존재
    - username, Status를 `hidden`으로 숨겨놓음

#### 보완할 사항
- 대표 및 경리 페이지에서 팀장을 지정할 때 새로운 `Team`과 `Division`이 생기도록 구현해야함!
- 위 과정이 완료되면 조금 더 매끄러운 코드로 리팩터링할 예정

### 먼저 개발이 되어야할 부분
- 대표 및 경리 페이지
    - 회원가입 승인 처리, 팀장 지정 등