### PR TITLE
입고등록 기능 구현, 공통 사용 ajax 생성

### DIFF
--- a/src/main/java/com/ezkorea/hybrid_app/domain/sale/SaleProductRepository.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/sale/SaleProductRepository.java
@@ -1,6 +1,13 @@
 package com.ezkorea.hybrid_app.domain.sale;
 
+import com.ezkorea.hybrid_app.domain.task.DailyTask;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SaleProductRepository extends JpaRepository<SaleProduct, Long> {
+
+    List<SaleProduct> findAllByTaskAndStatus(DailyTask task, String status);
+
+    void deleteByTaskAndStatus(DailyTask task, String status);
 }

--- a/src/main/java/com/ezkorea/hybrid_app/domain/task/DailyTask.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/task/DailyTask.java
@@ -17,7 +17,7 @@ import java.util.List;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@ToString(callSuper = true)
+@ToString(callSuper = true, exclude = "member")
 public class DailyTask extends BaseEntity {
 
     private LocalDate taskDate;

--- a/src/main/java/com/ezkorea/hybrid_app/web/controller/rest/SalesRestController.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/controller/rest/SalesRestController.java
@@ -1,7 +1,9 @@
 package com.ezkorea.hybrid_app.web.controller.rest;
 
+import com.ezkorea.hybrid_app.domain.sale.SaleProduct;
 import com.ezkorea.hybrid_app.domain.user.member.SecurityUser;
 import com.ezkorea.hybrid_app.service.sales.SaleService;
+import com.ezkorea.hybrid_app.web.dto.SaleProductDto;
 import com.ezkorea.hybrid_app.web.dto.WiperDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +11,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -32,6 +37,34 @@ public class SalesRestController {
 
         saleService.saveDailyGasStation((String) data.get("stationName"), securityUser.getMember());
 
+
+        return HttpStatus.OK;
+    }
+
+    @PostMapping("/sales/findInput")
+    public Map<String, Object> findInputProduct(@AuthenticationPrincipal SecurityUser securityUser) {
+        Map<String, Object> returnMap = new HashMap<>();
+        List<SaleProductDto> dtolist  = new ArrayList<>();
+        List<SaleProduct> inputList   = saleService.findInputProduct(securityUser.getMember());
+
+        inputList.forEach(item -> {
+            SaleProductDto dto = new SaleProductDto();
+            dto.setWiper(item.getWiper().getId());
+            dto.setCount(item.getCount());
+
+            dtolist.add(dto);
+        });
+
+        returnMap.put("result", dtolist);
+
+        return returnMap;
+    }
+
+    @PostMapping("/sales/input")
+    public HttpStatus saveInputProduct(@RequestBody List<SaleProductDto> data,
+                               @AuthenticationPrincipal SecurityUser securityUser) {
+
+        saleService.saveInputProduct(securityUser.getMember(), data);
 
         return HttpStatus.OK;
     }

--- a/src/main/java/com/ezkorea/hybrid_app/web/dto/SaleProductDto.java
+++ b/src/main/java/com/ezkorea/hybrid_app/web/dto/SaleProductDto.java
@@ -1,0 +1,12 @@
+package com.ezkorea.hybrid_app.web.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SaleProductDto {
+    private String status;
+    private int count;
+    private Long wiper;
+}

--- a/src/main/resources/static/assets/js/common.js
+++ b/src/main/resources/static/assets/js/common.js
@@ -1,0 +1,61 @@
+// input 범위지정
+function checkNumber($obj, min, max) {
+    if(!($obj.val() >= min && $obj.val() <= max)) $obj.val("");
+}
+
+// ajax 메소드:post, 파라미터:json, Fire
+function fnPostFireJsonAjax(data, url, fnCallBack, successMsg) {
+
+    $.ajax({
+        type: 'post',
+        url: url,
+        dataType: 'json',
+        contentType: 'application/json; charset=utf-8',
+        data: JSON.stringify(data),
+        beforeSend: function(jqXHR, settings) {
+            var header = $("meta[name='_csrf_header']").attr("content");
+            var token = $("meta[name='_csrf']").attr("content");
+            jqXHR.setRequestHeader(header, token);
+        },
+        success: function(data) {
+            Swal.fire({
+                icon: 'success',
+                text: successMsg,
+            }).then(() => {
+                if(fnCallBack) fnCallBack(data);
+            })
+        },
+        error: function(xhr, status, error) {
+            Swal.fire({
+                icon: 'error',
+                text: '오류가 발생했습니다.',
+            });
+        }
+    });
+}
+
+// ajax 메소드:post, 파라미터:json
+function fnPostJsonAjax(data, url, fnCallBack) {
+
+    $.ajax({
+        type: 'post',
+        url: url,
+        dataType: 'json',
+        contentType: 'application/json; charset=utf-8',
+        data: JSON.stringify(data),
+        beforeSend: function(jqXHR, settings) {
+            var header = $("meta[name='_csrf_header']").attr("content");
+            var token = $("meta[name='_csrf']").attr("content");
+            jqXHR.setRequestHeader(header, token);
+        },
+        success: function(data) {
+            if(fnCallBack) fnCallBack(data);
+        },
+        error: function(xhr, status, error) {
+            Swal.fire({
+                icon: 'error',
+                text: '오류가 발생했습니다.',
+            });
+        }
+    });
+}

--- a/src/main/resources/static/assets/js/common.js
+++ b/src/main/resources/static/assets/js/common.js
@@ -3,11 +3,11 @@ function checkNumber($obj, min, max) {
     if(!($obj.val() >= min && $obj.val() <= max)) $obj.val("");
 }
 
-// ajax 메소드:post, 파라미터:json, Fire
-function fnPostFireJsonAjax(data, url, fnCallBack, successMsg) {
+// ajax 메소드:post, put, delete, 파라미터:json
+function fnCrudJsonAjax(data, url, fnCallBack, method, successMsg) {
 
     $.ajax({
-        type: 'post',
+        type: method,
         url: url,
         dataType: 'json',
         contentType: 'application/json; charset=utf-8',
@@ -35,7 +35,7 @@ function fnPostFireJsonAjax(data, url, fnCallBack, successMsg) {
 }
 
 // ajax 메소드:post, 파라미터:json
-function fnPostJsonAjax(data, url, fnCallBack) {
+function fnFindJsonAjax(data, url, fnCallBack) {
 
     $.ajax({
         type: 'post',

--- a/src/main/resources/templates/layout/fragments/common/head.html
+++ b/src/main/resources/templates/layout/fragments/common/head.html
@@ -82,6 +82,7 @@
     <script src="/assets/js/uikit.js"></script>
     <script src="/assets/js/simplebar.js"></script>
     <script src="/assets/js/custom.js"></script>
+    <script src="/assets/js/common.js"></script>
     <script src="/assets/js/bootstrap-select.min.js"></script>
     <script src="https://unpkg.com/ionicons@5.2.3/dist/ionicons.js"></script>
     <script src="//cdn.jsdelivr.net/npm/sweetalert2@11"></script>

--- a/src/main/resources/templates/sales/in-detail.html
+++ b/src/main/resources/templates/sales/in-detail.html
@@ -73,56 +73,55 @@
             </div>
 
         </div>
+        <script>
 
+            $(document).ready(function(){
+
+                // 입고등록
+                $("#submit").on("click", function() {
+                    fnSaveInputProduct();
+                });
+
+                // 범위지정 (1~100)
+                $("#dataForm input").on("keyup", function() {
+                    checkNumber($(this), 1, 100);
+                });
+
+                fnFindInputProduct();
+            });
+
+            // 입고조회
+            function fnFindInputProduct() {
+                const url = "/sales/findInput";
+
+                fnFindJsonAjax("", url, fnFindInputProductResult);
+            }
+
+            // 입고등록
+            function fnSaveInputProduct() {
+                const url = "/sales/input";
+                const data = [];
+                const form = $('#dataForm').serializeArray();
+                form.forEach(function(item) {
+                    data.push({
+                        "wiper" : item.name,
+                        "count" : item.value
+                    })
+                })
+
+                fnCrudJsonAjax(data, url, null, "post", "정상적으로 저장되었습니다.");
+            }
+
+            function fnFindInputProductResult(data) {
+                const $form = $("#dataForm");
+
+                data.result.forEach(function(item) {
+                    $form.find("input[name=" + item.wiper + "]").val(item.count);
+                })
+            }
+
+        </script>
     </main>
 </body>
 
 </html>
-<script>
-
-    $(document).ready(function(){
-
-        // 입고등록
-        $("#submit").on("click", function() {
-            fnSaveInputProduct();
-        });
-
-        // 범위지정 (1~100)
-        $("#dataForm input").on("keyup", function() {
-            checkNumber($(this), 1, 100);
-        });
-
-        fnFindInputProduct();
-    });
-
-    // 입고조회
-    function fnFindInputProduct() {
-        const url = "/sales/findInput";
-
-        fnPostJsonAjax("", url, fnFindInputProductResult);
-    }
-
-    // 입고등록
-    function fnSaveInputProduct() {
-        const url = "/sales/input";
-        const data = [];
-        const form = $('#dataForm').serializeArray();
-        form.forEach(function(item) {
-            data.push({
-                "wiper" : item.name,
-                "count" : item.value
-            })
-        })
-
-        fnPostFireJsonAjax(data, url, null, "정상적으로 저장되었습니다.");
-    }
-
-    function fnFindInputProductResult(data) {
-        const $form = $("#dataForm");
-
-        data.result.forEach(function(item) {
-            $form.find("input[name=" + item.wiper + "]").val(item.count);
-        })
-    }
-
-</script>

--- a/src/main/resources/templates/sales/in-detail.html
+++ b/src/main/resources/templates/sales/in-detail.html
@@ -75,7 +75,54 @@
         </div>
 
     </main>
-
 </body>
 
 </html>
+<script>
+
+    $(document).ready(function(){
+
+        // 입고등록
+        $("#submit").on("click", function() {
+            fnSaveInputProduct();
+        });
+
+        // 범위지정 (1~100)
+        $("#dataForm input").on("keyup", function() {
+            checkNumber($(this), 1, 100);
+        });
+
+        fnFindInputProduct();
+    });
+
+    // 입고조회
+    function fnFindInputProduct() {
+        const url = "/sales/findInput";
+
+        fnPostJsonAjax("", url, fnFindInputProductResult);
+    }
+
+    // 입고등록
+    function fnSaveInputProduct() {
+        const url = "/sales/input";
+        const data = [];
+        const form = $('#dataForm').serializeArray();
+        form.forEach(function(item) {
+            data.push({
+                "wiper" : item.name,
+                "count" : item.value
+            })
+        })
+
+        fnPostFireJsonAjax(data, url, null, "정상적으로 저장되었습니다.");
+    }
+
+    function fnFindInputProductResult(data) {
+        const $form = $("#dataForm");
+
+        data.result.forEach(function(item) {
+            $form.find("input[name=" + item.wiper + "]").val(item.count);
+        })
+    }
+
+</script>


### PR DESCRIPTION
## 공통 사용 ajax 생성
common.js 생성 및 공용 함수 구현
`fnPostFireJsonAjax` : 등록, 수정, 업데이트
`fnPostJsonAjax`       : 조회
![20230129_033211](https://user-images.githubusercontent.com/77388722/215284788-430b1c44-4d83-4cd7-a342-860949c36e98.png)

## 입고등록 기능 구현
### 등록
- 입고등록 구현용 SaleProductDto생성 (wiper id값 변수가 존재해도 괜찮은건지)
- 값이 존재하는 input만 저장

### 조회
- 기본 등록 후 입고 페이지 접속시 조회

### 수정
- 입고는 추가가 아닌 수정의 개념으로 곧 당일 입고 현황이 된다(기존 입고 삭제 후 재 입력)

![20230129_033239](https://user-images.githubusercontent.com/77388722/215284760-e7f25668-96c7-4bdd-a939-722d95290a71.png)
