### PR TITLE
통계 최소금액 설정

### DIFF
--- a/src/main/java/com/ezkorea/hybrid_app/domain/timetable/PartTime.java
+++ b/src/main/java/com/ezkorea/hybrid_app/domain/timetable/PartTime.java
@@ -7,13 +7,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PartTime {
 
-    AM("am", "오전"),
-    PM("pm", "오후"),
-    FULL("full", "풀타임"),
-    IN("in", "입고");
+    AM("am", "오전", 200000),
+    PM("pm", "오후", 300000),
+    FULL("full", "풀타임", 500000),
+    IN("in", "입고", 0);
 
     private final String key;
     private final String viewName;
+    private final long minPrice;
 
     public static String of(String part) {
         for (PartTime partTime : PartTime.values()) {

--- a/src/main/java/com/ezkorea/hybrid_app/service/sales/SaleService.java
+++ b/src/main/java/com/ezkorea/hybrid_app/service/sales/SaleService.java
@@ -512,7 +512,22 @@ public class SaleService {
      * 일자별 모든 판매목록
      * */
     public List<Map<String, Object>> findDayStatList(Map<String, String> paramMap) {
-        return saleMbRepository.findDayStatList(paramMap);
+        List<Map<String, Object>> list = saleMbRepository.findDayStatList(paramMap);
+
+        // 파트타임, 타임별 최소금액
+        list.forEach(item -> {
+            PartTime part = PartTime.valueOf(((String)item.get("PART")).toUpperCase());
+            item.put("PART", part.getViewName());
+
+            BigDecimal result = new BigDecimal(String.valueOf(item.get("total")));
+            long total = result.longValue();
+            if(total < part.getMinPrice()) {
+                item.put("COLOR", "skyblue");
+            }
+
+        });
+
+        return list;
     }
 
 }

--- a/src/main/resources/mapper/saleProduct.xml
+++ b/src/main/resources/mapper/saleProduct.xml
@@ -270,22 +270,25 @@
 
     <select id="findDayStatList" parameterType="Map" resultType="Map">
         SELECT 	   MAX(A.NAME) AS NAME
-                 , IFNULL(SUM(CASE WHEN A.MEMBER_ID = A.MEMBER_ID AND A.SORT = 'normal' THEN A.COUNT END), 0) AS normal
-                 , IFNULL(SUM(CASE WHEN A.MEMBER_ID = A.MEMBER_ID AND A.SORT = 'hybrid' THEN A.COUNT END), 0) AS hybrid
-                 , IFNULL(SUM(CASE WHEN A.MEMBER_ID = A.MEMBER_ID AND A.SORT = 'mw' THEN A.COUNT END), 0) AS mw
-                 , IFNULL(SUM(CASE WHEN A.MEMBER_ID = A.MEMBER_ID AND A.SORT = 's_class' THEN A.COUNT END), 0) AS s_class
-                 , IFNULL(SUM(CASE WHEN A.MEMBER_ID = A.MEMBER_ID AND A.SORT = 'size_700' THEN A.COUNT END), 0) AS s_700
-                 , IFNULL(SUM(CASE WHEN A.MEMBER_ID = A.MEMBER_ID THEN A.PRICE END), 0) AS total
+                 , MAX(A.PART) AS PART
+                 , IFNULL(SUM(CASE WHEN A.TABLE_ID = A.TABLE_ID AND A.SORT = 'normal' THEN A.COUNT END), 0) AS normal
+                 , IFNULL(SUM(CASE WHEN A.TABLE_ID = A.TABLE_ID AND A.SORT = 'hybrid' THEN A.COUNT END), 0) AS hybrid
+                 , IFNULL(SUM(CASE WHEN A.TABLE_ID = A.TABLE_ID AND A.SORT = 'mw' THEN A.COUNT END), 0) AS mw
+                 , IFNULL(SUM(CASE WHEN A.TABLE_ID = A.TABLE_ID AND A.SORT = 's_class' THEN A.COUNT END), 0) AS s_class
+                 , IFNULL(SUM(CASE WHEN A.TABLE_ID = A.TABLE_ID AND A.SORT = 'size_700' THEN A.COUNT END), 0) AS s_700
+                 , IFNULL(SUM(CASE WHEN A.TABLE_ID = A.TABLE_ID THEN A.PRICE END), 0) AS total
         FROM
         (
             SELECT    CONCAT(MAX(B.NAME), (CASE WHEN MAX(B.TEAM_NAME) IS NULL THEN "" ELSE CONCAT("(", MAX(B.TEAM_NAME), ")") END)) AS NAME
                     , SUM(A.COUNT) / 2 AS COUNT
                     , SUM(A.COUNT) * MAX(C.PRICE) AS PRICE
                     , A.SORT
-                    , B.MEMBER_ID
+                    , MAX(B.PART) AS PART
+                    , B.TABLE_ID
             FROM    SELL_PRODUCT A INNER JOIN
             (
                 SELECT    A.ID AS TABLE_ID
+                        , A.PART
                         , B.ID AS MEMBER_ID
                         , B.NAME AS NAME
                         , C.TEAM_NAME AS TEAM_NAME
@@ -305,9 +308,10 @@
             ) C
             ON A.SORT = C.SORT
             WHERE A.STATUS = 'out'
-            GROUP BY B.MEMBER_ID, A.SORT
+            GROUP BY B.TABLE_ID, A.SORT
         ) A
-        GROUP BY A.MEMBER_ID
+        GROUP BY A.TABLE_ID
+        ORDER BY TOTAL DESC
     </select>
 
 </mapper>

--- a/src/main/resources/templates/manager/stat/manage-dayStat.html
+++ b/src/main/resources/templates/manager/stat/manage-dayStat.html
@@ -36,6 +36,9 @@
                                         이름
                                     </th>
                                     <th scope="col" class="text-center px-6 py-3">
+                                        파트
+                                    </th>
+                                    <th scope="col" class="text-center px-6 py-3">
                                         일반
                                     </th>
                                     <th scope="col" class="text-center px-6 py-3">
@@ -56,8 +59,9 @@
                                 </tr>
                                 </thead>
                                 <tbody th:each="stat : ${statList}">
-                                    <tr class="border-b border-gray-200 dark:border-gray-700">
+                                    <tr class="border-b border-gray-200 dark:border-gray-700" th:style="'background-color: ' + ${stat['COLOR']}">
                                         <th class="text-center px-6 py-4 font-medium whitespace-nowrap" th:text="${stat['NAME']}"></th>
+                                        <th class="text-center px-6 py-4 font-medium whitespace-nowrap" th:text="${stat['PART']}"></th>
                                         <td class="text-center px-6 py-4" th:text="|${#numbers.formatDecimal(stat.normal, 1, 1)}|"></td>
                                         <td class="text-center px-6 py-4" th:text="|${#numbers.formatDecimal(stat.hybrid, 1, 1)}|"></td>
                                         <td class="text-center px-6 py-4" th:text="|${#numbers.formatDecimal(stat.mw, 1, 1)}|"></td>


### PR DESCRIPTION
## 통계 최소금액 설정
### 매니징 - 금일 매출 조회 - 일일판매통계 - 판매 최소금액 설정
- 파트타임 오전, 오후, 풀타임 분리, 각 타임별 최소금액 설정
- 최소금액 미달성시 하늘색 배경 설정
- 오전 : 20만원
- 오후 : 30만원
- 풀타임 : 50만원

![image](https://user-images.githubusercontent.com/77388722/226183722-35ae48f7-3825-46f9-9152-e2f3eaec6af5.png)
